### PR TITLE
Introduce str2int as an alias to atoi, allowing plugins compilation

### DIFF
--- a/RFLink/4_Display.h
+++ b/RFLink/4_Display.h
@@ -103,6 +103,8 @@ boolean retrieve_End();
 #define VALUE_LIMIT 82
 #define VALUE_ALLON 141
 
+#define str2int(x) atoi(x)
+
 int str2cmd(char *);
 void replacechar(char *, char, char);
 


### PR DESCRIPTION
This to replicate this commit from Couin's repo: https://github.com/couin3/RFLink/pull/65/commits/6cfb81fef7670acb75f6ebc518f02f8e5829c821