### PR TITLE
RawSignal.Multiply is 0 when doing plugin initialization, it must not be used to do divisions

### DIFF
--- a/RFLink/Plugins/Plugin_001.c
+++ b/RFLink/Plugins/Plugin_001.c
@@ -89,6 +89,9 @@
 
 boolean Plugin_001(byte function, const char *string)
 {
+    if (string == NULL || RawSignal.Number == 0)
+        return false;
+
    // byte HEconversiontype = 1; // 0=No conversion, 1=conversion to Elro 58 pulse protocol (same as FA500R Method 1)
    const long PULSE500 = PULSE500_D / RawSignal.Multiply;
    const long PULSE1100 = PULSE1100_D / RawSignal.Multiply;

--- a/RFLink/Plugins/Plugin_003.c
+++ b/RFLink/Plugins/Plugin_003.c
@@ -227,9 +227,6 @@
 
 boolean Plugin_003(byte function, const char *string)
 {
-   const long KAKU_R = KAKU_R_D / RawSignal.Multiply;
-   const long KAKU_PULSEMID = KAKU_PULSEMID_D / RawSignal.Multiply;
-
    if (RawSignal.Number != (KAKU_CodeLength * 4) + 2)
       return false; // conventionele KAKU bestaat altijd uit 12 data bits plus stop. Ongelijk, dan geen KAKU!
    if (RawSignal.Pulses[0] == 15)
@@ -239,6 +236,9 @@ boolean Plugin_003(byte function, const char *string)
    if (RawSignal.Pulses[0] == 19)
       return false; // No need to test, packet for plugin 19
    // -------------------------------------------
+   const long KAKU_R = KAKU_R_D / RawSignal.Multiply;
+   const long KAKU_PULSEMID = KAKU_PULSEMID_D / RawSignal.Multiply;
+
    int i, j;
    boolean error = false;
    unsigned long bitstream = 0L;  // to store a 12 bit code (ARC type)

--- a/RFLink/Plugins/Plugin_004.c
+++ b/RFLink/Plugins/Plugin_004.c
@@ -54,12 +54,12 @@
 
 boolean Plugin_004(byte function, const char *string)
 {
-   const long NewKAKU_mT = NewKAKU_mT_D / RawSignal.Multiply;
    // nieuwe KAKU bestaat altijd uit start bit + 32 bits + evt 4 dim bits. Ongelijk, dan geen NewKAKU
    if ((RawSignal.Number != NewKAKU_RawSignalLength) && (RawSignal.Number != NewKAKUdim_RawSignalLength))
       return false;
    if (RawSignal.Pulses[0] == 15)
       return true; // Home Easy, skip KAKU
+   const long NewKAKU_mT = NewKAKU_mT_D / RawSignal.Multiply;
    boolean Bit = 0;
    int i;
 #if defined(ESP32) || defined(ESP8266)

--- a/RFLink/Plugins/Plugin_006.c
+++ b/RFLink/Plugins/Plugin_006.c
@@ -45,10 +45,10 @@
 
 boolean Plugin_006(byte function, const char *string)
 {
-   const long BLYSS_PULSEMID = BLYSS_PULSEMID_D / RawSignal.Multiply;
-
    if (RawSignal.Number != BLYSS_PULSECOUNT)
       return false;
+
+   const long BLYSS_PULSEMID = BLYSS_PULSEMID_D / RawSignal.Multiply;
    unsigned long bitstream = 0L;
    unsigned long bitstream1 = 0L;
    byte bitcounter = 0;

--- a/RFLink/Plugins/Plugin_011.c
+++ b/RFLink/Plugins/Plugin_011.c
@@ -90,12 +90,13 @@
 
 boolean Plugin_011(byte function, const char *string)
 {
+  if (RawSignal.Number != HC_PULSECOUNT) // Incorrect pulse count
+      return false;
+
    const long HC_PULSE_PREAMBLE = HC_PULSE_PREAMBLE_D / RawSignal.Multiply;
    const long HC_PULSE_MID = HC_PULSE_MID_D / RawSignal.Multiply;
    const long HC_PULSE_MAX = HC_PULSE_MAX_D / RawSignal.Multiply;
 
-  if (RawSignal.Number != HC_PULSECOUNT) // Incorrect pulse count
-      return false;
   if (RawSignal.Pulses[1] < HC_PULSE_PREAMBLE )
       return false; // First (start) pulse needs to be long
 

--- a/RFLink/Plugins/Plugin_014.c
+++ b/RFLink/Plugins/Plugin_014.c
@@ -47,13 +47,13 @@
 
 boolean Plugin_014(byte function, const char *string)
 {
-   const long KOPPLA_PULSEMID = KOPPLA_PULSEMID_D / RawSignal.Multiply;
-   const long KOPPLA_PULSEMAX = KOPPLA_PULSEMAX_D / RawSignal.Multiply;
-   const long KOPPLA_PULSEMIN = KOPPLA_PULSEMIN_D / RawSignal.Multiply;
-
    if ((RawSignal.Number < KOPPLA_PulseLength_MIN) || (RawSignal.Number > KOPPLA_PulseLength_MAX))
       return false;
    unsigned long bitstream = 0L;
+
+   const long KOPPLA_PULSEMID = KOPPLA_PULSEMID_D / RawSignal.Multiply;
+   const long KOPPLA_PULSEMAX = KOPPLA_PULSEMAX_D / RawSignal.Multiply;
+   const long KOPPLA_PULSEMIN = KOPPLA_PULSEMIN_D / RawSignal.Multiply;
 
    // byte preamble = 0; // unused?
    unsigned int sysunit = 0;

--- a/RFLink/Plugins/Plugin_016.c
+++ b/RFLink/Plugins/Plugin_016.c
@@ -19,15 +19,16 @@ boolean Plugin_016(byte function, const char *string)
 {
    const int SLVCR_MinPulses = 180;
    const int SLVCR_MaxPulses = 320;
-   const int SLVCR_StartPulseDuration = 2000 / RawSignal.Multiply;
-   const int SLVCR_LongPulseMinDuration = 900 / RawSignal.Multiply;
-   const int SLVCR_LongPulseMaxDuration = 1400 / RawSignal.Multiply;
-   const int SLVCR_ShortPulseMinDuration = 200 / RawSignal.Multiply;
-   const int SLVCR_ShortPulseMaxDuration = 600 / RawSignal.Multiply;
-   const int SLVCR_PulsesCount = SLVCR_BitCount * 2;
 
    if (RawSignal.Number >= SLVCR_MinPulses && RawSignal.Number <= SLVCR_MaxPulses) 
    {
+      const int SLVCR_StartPulseDuration = 2000 / RawSignal.Multiply;
+      const int SLVCR_LongPulseMinDuration = 900 / RawSignal.Multiply;
+      const int SLVCR_LongPulseMaxDuration = 1400 / RawSignal.Multiply;
+      const int SLVCR_ShortPulseMinDuration = 200 / RawSignal.Multiply;
+      const int SLVCR_ShortPulseMaxDuration = 600 / RawSignal.Multiply;
+      const int SLVCR_PulsesCount = SLVCR_BitCount * 2;
+
       // Look for an overly long "off" pulse, followed by SLVCR_PulsesCount then again by an overly long "off" pulse
       // Ignore the first pulses, they are too noisy to be reliable
       int pulseIndex = 30; 

--- a/RFLink/Plugins/Plugin_017.c
+++ b/RFLink/Plugins/Plugin_017.c
@@ -52,15 +52,15 @@ boolean Plugin_017(byte function, const char *string)
 
    // ;Pulses=82;Pulses(uSec)=2449,2542,4787,1299,1264,674,612,1311,1263,1301,1261,666,608,1315,1255,683,610,663,615,679,611,1299,1263,1307,611,679,1263,663,611,1309,610,666,1255,1315,1255,682,606,1316,611,665,605,678,1248,679,611,1310,1259,1300,611,679,1259,1311,1259,1311,1263,675,603,679,611,1311,1259,667,611,1311,1259,1311,611,667,611,679,611,667,612,678,1247,1315,608,678,600,678,1260,0
 
-    const int RTS_HardwareSyncPulseDuration = 2000 / RawSignal.Multiply;
-    const int RTS_LongPulseMinDuration = 1000 / RawSignal.Multiply;
-    const int RTS_ShortPulseMinDuration = 500 / RawSignal.Multiply;
-    const int RTS_ShortPulseMaxDuration = 750 / RawSignal.Multiply;
-    DeclareRTS_SoftwareSyncPulseDuration;
-    const int RTS_MinRepeatHardwareSyncCount = 5;
-
    if (RawSignal.Number >= RTS_MinPulses && RawSignal.Number <= RTS_MaxPulses) 
    {
+        const int RTS_HardwareSyncPulseDuration = 2000 / RawSignal.Multiply;
+        const int RTS_LongPulseMinDuration = 1000 / RawSignal.Multiply;
+        const int RTS_ShortPulseMinDuration = 500 / RawSignal.Multiply;
+        const int RTS_ShortPulseMaxDuration = 750 / RawSignal.Multiply;
+        DeclareRTS_SoftwareSyncPulseDuration;
+        const int RTS_MinRepeatHardwareSyncCount = 5;
+
         #ifdef PLUGIN_017_DEBUG
         Serial.println(F(PLUGIN_017_ID ": Potential candidate packet"));
         Serial.print(F(PLUGIN_017_ID ": RTS_SoftwareSyncPulseDuration = "));

--- a/RFLink/Plugins/Plugin_029.c
+++ b/RFLink/Plugins/Plugin_029.c
@@ -66,14 +66,14 @@ uint8_t Plugin_029_ProtocolAlectoCRC8(uint8_t *addr, uint8_t len);
 
 boolean Plugin_029(byte function, const char *string)
 {
-  const long DKW2012_PULSEMINMAX = DKW2012_PULSEMINMAX_D / RawSignal.Multiply;
-
   if (!(
           ((RawSignal.Number >= ACH2010_MIN_PULSECOUNT) &&
            (RawSignal.Number <= ACH2010_MAX_PULSECOUNT)) ||
           ((RawSignal.Number >= DKW2012_MIN_PULSECOUNT) &&
            (RawSignal.Number <= DKW2012_MAX_PULSECOUNT))))
     return false;
+
+  const long DKW2012_PULSEMINMAX = DKW2012_PULSEMINMAX_D / RawSignal.Multiply;
 
   byte c = 0;
   byte data[10];

--- a/RFLink/Plugins/Plugin_033.c
+++ b/RFLink/Plugins/Plugin_033.c
@@ -43,11 +43,11 @@
 
 boolean Plugin_033(byte function, const char *string)
 {
-   const long CONRAD_PULSEMAX = CONRAD_PULSEMAX_D / RawSignal.Multiply;
-   const long CONRAD_PULSEMIN = CONRAD_PULSEMIN_D / RawSignal.Multiply;
-
    if (RawSignal.Number != CONRAD_PULSECOUNT)
       return false;
+
+   const long CONRAD_PULSEMAX = CONRAD_PULSEMAX_D / RawSignal.Multiply;
+   const long CONRAD_PULSEMIN = CONRAD_PULSEMIN_D / RawSignal.Multiply;
 
    unsigned long bitstream = 0L;
    byte checksum = 0;

--- a/RFLink/Plugins/Plugin_036.c
+++ b/RFLink/Plugins/Plugin_036.c
@@ -41,10 +41,10 @@
 
 boolean Plugin_036(byte function, const char *string)
 {
-   const long F007_TH_PULSE_MID = F007_TH_PULSE_MID_D / RawSignal.Multiply;
-
    if (RawSignal.Number != F007_TH_PULSECOUNT)
       return false;
+
+   const long F007_TH_PULSE_MID = F007_TH_PULSE_MID_D / RawSignal.Multiply;
 
    byte toggle = 1;
    byte pulsecounter = 2;                                            // Pulse counter

--- a/RFLink/Plugins/Plugin_037.c
+++ b/RFLink/Plugins/Plugin_037.c
@@ -53,13 +53,13 @@
 
 boolean Plugin_037(byte function, const char *string)
 {
+   if (RawSignal.Number < ACURITE_PULSECOUNT || RawSignal.Number > (ACURITE_PULSECOUNT + 4))
+      return false;
+
    const long ACURITE_MIDHI = ACURITE_MIDHI_D / RawSignal.Multiply;
    const long ACURITE_PULSEMIN = ACURITE_PULSEMIN_D / RawSignal.Multiply;
    const long ACURITE_PULSEMINMAX = ACURITE_PULSEMINMAX_D / RawSignal.Multiply;
    const long ACURITE_PULSEMAXMIN = ACURITE_PULSEMAXMIN_D / RawSignal.Multiply;
-
-   if (RawSignal.Number < ACURITE_PULSECOUNT || RawSignal.Number > (ACURITE_PULSECOUNT + 4))
-      return false;
 
    unsigned long bitstream = 0L;
    byte bitstream2 = 0;

--- a/RFLink/Plugins/Plugin_040.c
+++ b/RFLink/Plugins/Plugin_040.c
@@ -58,17 +58,17 @@
 
 boolean Plugin_040(byte function, const char *string)
 {
-   const long MEBUS_MIDHI = MEBUS_MIDHI_D / RawSignal.Multiply;
-   const long MEBUS_PULSEMIN = MEBUS_PULSEMIN_D / RawSignal.Multiply;
-   const long MEBUS_PULSEMINMAX = MEBUS_PULSEMINMAX_D / RawSignal.Multiply;
-   const long MEBUS_PULSEMAXMIN = MEBUS_PULSEMAXMIN_D / RawSignal.Multiply;
-
    if (RawSignal.Number != MEBUS_PULSECOUNT) {
      #ifdef PLUGIN_040_DEBUG
      Serial.println(F("Mebus: failed  RawSignal.Number != MEBUS_PULSECOUNT"));
      #endif
      return false;
    }
+
+   const long MEBUS_MIDHI = MEBUS_MIDHI_D / RawSignal.Multiply;
+   const long MEBUS_PULSEMIN = MEBUS_PULSEMIN_D / RawSignal.Multiply;
+   const long MEBUS_PULSEMINMAX = MEBUS_PULSEMINMAX_D / RawSignal.Multiply;
+   const long MEBUS_PULSEMAXMIN = MEBUS_PULSEMAXMIN_D / RawSignal.Multiply;
 
    unsigned long bitstream = 0L;
    unsigned int temperature = 0;

--- a/RFLink/Plugins/Plugin_041.c
+++ b/RFLink/Plugins/Plugin_041.c
@@ -94,11 +94,11 @@
 
 boolean Plugin_041(byte function, const char *string)
 {
-   const long LACROSSE41_PULSEMID = LACROSSE41_PULSEMID_D / RawSignal.Multiply;
-
    if ((RawSignal.Number != LACROSSE41_PULSECOUNT1) && (RawSignal.Number != LACROSSE41_PULSECOUNT2) &&
        (RawSignal.Number != LACROSSE41_PULSECOUNT3) && (RawSignal.Number != LACROSSE41_PULSECOUNT4))
       return false;
+
+   const long LACROSSE41_PULSEMID = LACROSSE41_PULSEMID_D / RawSignal.Multiply;
 
    byte data[18];
    byte bitcounter = 0;  // counts number of received bits (converted from pulses)

--- a/RFLink/Plugins/Plugin_043.c
+++ b/RFLink/Plugins/Plugin_043.c
@@ -103,15 +103,15 @@
 
 boolean Plugin_043(byte function, const char *string)
 {
+   if ((RawSignal.Number < LACROSSE43_PULSECOUNT - 4) || (RawSignal.Number > LACROSSE43_PULSECOUNT + 4))
+      return false;
+
    const long LACROSSE43_MIDLO = LACROSSE43_MIDLO_D / RawSignal.Multiply;
    const long LACROSSE43_MIDHI = LACROSSE43_MIDHI_D / RawSignal.Multiply;      //1500 //1050
    const long LACROSSE43_PULSEMINMAX = LACROSSE43_PULSEMINMAX_D / RawSignal.Multiply; //810 //570
    const long LACROSSE43_PULSEMAXMIN = LACROSSE43_PULSEMAXMIN_D / RawSignal.Multiply; //1410 //990
    const long LACROSSE43_PULSEMAX = LACROSSE43_PULSEMAX_D / RawSignal.Multiply;   //2100 //1500
 
-
-   if ((RawSignal.Number < LACROSSE43_PULSECOUNT - 4) || (RawSignal.Number > LACROSSE43_PULSECOUNT + 4))
-      return false;
 
    unsigned long bitstream1 = 0L; // holds first 5x4=20 bits
    unsigned long bitstream2 = 0L; // holds last  6x4=24 bits

--- a/RFLink/Plugins/Plugin_083.c
+++ b/RFLink/Plugins/Plugin_083.c
@@ -44,12 +44,12 @@
 
 boolean Plugin_083(byte function, const char *string)
 {
-   const long DOOYA_MIDVALUE = DOOYA_MIDVALUE_D / RawSignal.Multiply;
-   
-   char dbuffer[64];
-
       if ( RawSignal.Number == DOOYA_PULSECOUNT_1 ) 
       {
+         const long DOOYA_MIDVALUE = DOOYA_MIDVALUE_D / RawSignal.Multiply;
+        
+         char dbuffer[64];
+
          byte bbuffer[128];
 
 #ifdef PLUGIN_083_DEBUG


### PR DESCRIPTION
This happens via PluginInitCall and so we must not use its value to perform "const" computation.

This leads to crashes when the image is built in debug mode.