### PR TITLE
RTS fixes

### DIFF
--- a/RFLink/1_Radio.cpp
+++ b/RFLink/1_Radio.cpp
@@ -1145,7 +1145,7 @@ namespace RFLink { namespace Radio  {
     bool initialize_RFM69_legacy() {
       radio.reset();
       radio.initialize();
-      radio.setFrequency(433920000);
+      radio.setFrequency(params::frequency);
       Serial.printf_P(PSTR("RFM69 initialized with Freq = %.2f\r\n"), (double)radio.getFrequency()/1000000);
       //Serial.print("Temp = "); Serial.println(radio.readTemperature());
       if(hardware == HardwareType::HW_RFM69HCW_t)

--- a/RFLink/Plugins/Plugin_017.c
+++ b/RFLink/Plugins/Plugin_017.c
@@ -546,7 +546,7 @@ boolean PluginTX_017(byte function, const char *string)
         sendFrame(frame, false);
 
     // store next code 
-    saveRTSRecord(eepromRecordNumber, address, code++);
+    saveRTSRecord(eepromRecordNumber, address, ++code);
 
     return true;
 }
@@ -563,6 +563,7 @@ void saveRTSRecord(uint8_t eepromRecordNumber, uint32_t address, uint16_t rollin
 void sendFrame(uint8_t* frame, bool isFirst)
 {
     uint32_t originalFrequency = Radio::setFrequency(433420000);
+    RawSignal.Multiply = 1;
 
     const int RTS_HalfBitPulseDuration = 640 / RawSignal.Multiply;
     const int RTS_WakeUpPulseDuration = 9415 / RawSignal.Multiply;
@@ -580,7 +581,7 @@ void sendFrame(uint8_t* frame, bool isFirst)
     }
 
     // Hardware sync: two sync for the first frame, seven for the following ones.
-    for (int i = 0; i < (isFirst) ? 2 : 7; i++) {
+    for (int i = 0; i < (isFirst ? 2 : 7) ; i++) {
         digitalWrite(Radio::pins::TX_DATA, HIGH);
         delayMicroseconds(4 * RTS_HalfBitPulseDuration);
         digitalWrite(Radio::pins::TX_DATA, LOW);
@@ -615,6 +616,7 @@ void sendFrame(uint8_t* frame, bool isFirst)
     digitalWrite(Radio::pins::TX_DATA, LOW);
     delayMicroseconds(RTS_InterframeSilenceDuration); // Inter-frame silence
 
+    RawSignal.Multiply = RFLink::Signal::params::sample_rate; // restore setting
     Radio::setFrequency(originalFrequency);
 }
 

--- a/RFLink/Plugins/Plugin_017.c
+++ b/RFLink/Plugins/Plugin_017.c
@@ -379,12 +379,8 @@ boolean PluginTX_017(byte function, const char *string)
                 return false;
             }
 
-            Serial.print(F("RTS Record: "));
-            Serial.print(recordNumber);
-            Serial.print(F(" Address: "));
-            Serial.print(addressInFile & 0xFFFFFF, 16);
-            Serial.print(F(" RC: "));
-            Serial.println(codeInFile, 16);
+            sprintf(printBuf, PSTR("RTS Record: %d  Address: %06X  RC: %04X"), recordNumber, (addressInFile & 0xFFFFFF), codeInFile);
+            sendRawPrint(printBuf, true);
         }
         file.close();
         return true;

--- a/RFLink/RFLink.cpp
+++ b/RFLink/RFLink.cpp
@@ -313,6 +313,10 @@ namespace RFLink {
 
     bool executeCliCommand(char *cmd) {
       static byte ValidCommand = 0;
+
+      // Copy input command to InputBuffer_Serial, because many plugins are based on it !
+      memcpy(InputBuffer_Serial, cmd, INPUT_COMMAND_SIZE);
+
       if (strlen(cmd) > 7) { // need to see minimal 8 characters on the serial port
         // 10;....;..;ON;
         if (strncmp(cmd, "10;", 3) == 0) { // Command from Master to RFLink


### PR DESCRIPTION
Hi,

This pull request addresses two issues : 
- RFM69 was not initialized with the frequency set in parameters. This was not a problem for RTS, but it makes more complex to understand why the radio doesn't records RTS data since the radio was on the wrong frequency.
- The Plugin_017 (RTS) was crashing when sending data, because of Multiply variable being equal to zero (don't ask me why !), and because the for loop in sendFrame exit test was never met (I'm not sure about the reason, but adding parenthesis to the ternary test did fix it). 
- Also, the Rolling code in the Plugin_017 was incremented after save, so was never saved with the correct value.

I did test all those modifications on my Somfy stores, they seems to work correctly. However, I don't have any other harware to test other plugins.