### PR TITLE
Add support for extra SilverCrest remotes/sockets

### DIFF
--- a/RFLink/4_Display.cpp
+++ b/RFLink/4_Display.cpp
@@ -512,7 +512,7 @@ boolean retrieve_ID(unsigned long &ul_ID)
 
 boolean retrieve_Switch(byte &b_Switch)
 {
-    return retrieve_nibble(b_Switch, "SWITCH=");
+    return retrieve_byte(b_Switch, "SWITCH=");
 }
 
 boolean retrieve_Command(byte &b_Cmd)

--- a/RFLink/4_Display.h
+++ b/RFLink/4_Display.h
@@ -106,7 +106,7 @@ boolean retrieve_byte(byte &, const char* = NULL);  // calls retrieve_hexNumber(
 boolean retrieve_nibble(byte &, const char* = NULL);  // calls retrieve_hexNumber(, 1, )
 
 boolean retrieve_ID(unsigned long &);  // calls retrieve_long(, "ID=") and limits the value to 0x03FFFFFF (26 bits)
-boolean retrieve_Switch(byte &);  // calls retrieve_nibble(, "SWITCH=")
+boolean retrieve_Switch(byte &);  // calls retrieve_byte(, "SWITCH=")
 boolean retrieve_Command(byte &); // calls retrieve_command(, "CMD=") 
 
 boolean retrieve_End();  // returns true if the token "pointer" is at the end of the input string

--- a/RFLink/Plugins/Plugin_004.c
+++ b/RFLink/Plugins/Plugin_004.c
@@ -198,7 +198,7 @@ boolean  PluginTX_004(byte function, const char *string)
 
 
    bitstream = (ID_bitstream << 6); // 26 bits on top
-   bitstream |= Switch_bitstream; // Complete transmitted address
+   bitstream |= Switch_bitstream & 0xF; // Complete transmitted address
    // bitstream &= 0xFFFFFFCF;    // Bit 4 and 5 are left for cmd
    bitstream |= (Cmd_bitstream << 4);
 


### PR DESCRIPTION
Different silvercrest remotes generate different codes, this adds support for remotes 0x5 and 0xD as described at https://github.com/couin3/RFLink/issues/66 and fixes a bug in parsing of requests that made this remote incompatible with Home Assistant